### PR TITLE
Simplify API function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ func main() {
 	// TIMEOUT_SECONDS is not set, so its fallback will be used.
 
 	// --- Initialize Configura ---
-	cfg := configura.NewConfigImpl()
+	cfg := configura.New()
 
 	// Load environment variables with fallbacks
-	configura.LoadEnvironment(cfg, config.DATABASE_URL, "postgres://fallback_user:fallback_pass@localhost:5432/fallback_db")
-	configura.LoadEnvironment(cfg, config.PORT, 3000)  // Fallback port 3000
-	configura.LoadEnvironment(cfg, config.API_KEY, "") // Fallback empty string if not set
-	configura.LoadEnvironment(cfg, config.ENABLE_FEATURE_X, false)
-	configura.LoadEnvironment(cfg, config.TIMEOUT_SECONDS, int64(30)) // Fallback 30 seconds
-	configura.LoadEnvironment(cfg, subpackage.SUBPACKAGE_DEFINED_CONFIG, "default_value")
+	configura.Load(cfg, config.DATABASE_URL, "postgres://fallback_user:fallback_pass@localhost:5432/fallback_db")
+	configura.Load(cfg, config.PORT, 3000)  // Fallback port 3000
+	configura.Load(cfg, config.API_KEY, "") // Fallback empty string if not set
+	configura.Load(cfg, config.ENABLE_FEATURE_X, false)
+	configura.Load(cfg, config.TIMEOUT_SECONDS, int64(30)) // Fallback 30 seconds
+	configura.Load(cfg, subpackage.SUBPACKAGE_DEFINED_CONFIG, "default_value")
 
 	// Set the configuration by yourself
-	cfg.RegInt64[config.TIMEOUT_SECONDS] = int64(25)
+	configura.Write(cfg, map[configura.Variable[int64]]int64{config.TIMEOUT_SECONDS: 25})
 
 	err := subpackage.Initialize(cfg)
 	if err != nil {
@@ -115,7 +115,7 @@ var RequiredUserServiceKeys = []any{
 // It validates that all required configuration keys are registered.
 func Initialize(cfg configura.Config) error {
 	// Validate that the config instance has all the keys our service needs
-	if err := cfg.ConfigurationKeysRegistered(RequiredUserServiceKeys...); err != nil {
+	if err := cfg.Exists(RequiredUserServiceKeys...); err != nil {
 		return fmt.Errorf("user service configuration validation failed: %w", err)
 	}
 
@@ -131,9 +131,9 @@ func Initialize(cfg configura.Config) error {
 }
 ```
 
-### How `ConfigurationKeysRegistered` Works
+### How `Exists` Works
 
-The `ConfigurationKeysRegistered` method iterates through the provided keys. If any key is not found in the `ConfigImpl`'s internal maps (meaning `LoadEnvironment` was not called for it, or it wasn't otherwise set), it returns a `ErrMissingVariable`. This error contains a list of all the missing keys.
+The `Exists` method iterates through the provided keys. If any key is not found in the `Config`'s internal maps (meaning `Load` was not called for it, or it wasn't otherwise set), it returns a `ErrMissingVariable`. This error contains a list of all the missing keys.
 
 This allows for robust startup checks, ensuring your application components have the configuration they need before they start running.
 

--- a/_example/main.go
+++ b/_example/main.go
@@ -19,18 +19,18 @@ func main() {
 	// TIMEOUT_SECONDS is not set, so its fallback will be used.
 
 	// --- Initialize Configura ---
-	cfg := configura.NewConfigImpl()
+	cfg := configura.New()
 
 	// Load environment variables with fallbacks
-	configura.LoadEnvironment(cfg, config.DATABASE_URL, "postgres://fallback_user:fallback_pass@localhost:5432/fallback_db")
-	configura.LoadEnvironment(cfg, config.PORT, 3000)  // Fallback port 3000
-	configura.LoadEnvironment(cfg, config.API_KEY, "") // Fallback empty string if not set
-	configura.LoadEnvironment(cfg, config.ENABLE_FEATURE_X, false)
-	configura.LoadEnvironment(cfg, config.TIMEOUT_SECONDS, int64(30)) // Fallback 30 seconds
-	configura.LoadEnvironment(cfg, subpackage.SUBPACKAGE_DEFINED_CONFIG, "default_value")
+	configura.Load(cfg, config.DATABASE_URL, "postgres://fallback_user:fallback_pass@localhost:5432/fallback_db")
+	configura.Load(cfg, config.PORT, 3000)  // Fallback port 3000
+	configura.Load(cfg, config.API_KEY, "") // Fallback empty string if not set
+	configura.Load(cfg, config.ENABLE_FEATURE_X, false)
+	configura.Load(cfg, config.TIMEOUT_SECONDS, int64(30)) // Fallback 30 seconds
+	configura.Load(cfg, subpackage.SUBPACKAGE_DEFINED_CONFIG, "default_value")
 
 	// Set the configuration by yourself
-	cfg.RegInt64[config.TIMEOUT_SECONDS] = int64(25)
+	configura.Write(cfg, map[configura.Variable[int64]]int64{config.TIMEOUT_SECONDS: 25})
 
 	err := subpackage.Initialize(cfg)
 	if err != nil {

--- a/_example/subpackage/subpackage.go
+++ b/_example/subpackage/subpackage.go
@@ -22,7 +22,7 @@ var RequiredUserServiceKeys = []any{
 // It validates that all required configuration keys are registered.
 func Initialize(cfg configura.Config) error {
 	// Validate that the config instance has all the keys our service needs
-	if err := cfg.ConfigurationKeysRegistered(RequiredUserServiceKeys...); err != nil {
+	if err := cfg.Exists(RequiredUserServiceKeys...); err != nil {
 		return fmt.Errorf("user service configuration validation failed: %w", err)
 	}
 

--- a/configura_test.go
+++ b/configura_test.go
@@ -14,46 +14,39 @@ import (
 
 // --- Test Suite Definitions ---
 
-// ConfigSuite tests the Config interface and ConfigImpl methods
 type ConfigSuite struct {
 	suite.Suite
-	config *ConfigImpl
+	config Config
 }
 
-// LoadEnvironmentSuite tests the LoadEnvironment function
-type LoadEnvironmentSuite struct {
+type LoadSuite struct {
 	suite.Suite
 }
 
-// FormatKeysSuite tests the formatKeys function
-type FormatKeysSuite struct {
+type ExistsSuite struct {
 	suite.Suite
 }
 
-// CheckKeySuite tests the checkKey method of ConfigImpl
-type CheckKeySuite struct {
-	suite.Suite
-}
-
-// ConfigurationKeysRegisteredSuite tests the ConfigurationKeysRegistered method
-type ConfigurationKeysRegisteredSuite struct {
-	suite.Suite
-}
-
-// FallbackSuite tests the Fallback function
 type FallbackSuite struct {
 	suite.Suite
 }
 
-// MergeSuite tests the Merge function.
 type MergeSuite struct {
+	suite.Suite
+}
+
+type FormatKeysSuite struct {
+	suite.Suite
+}
+
+type CheckKeySuite struct {
 	suite.Suite
 }
 
 // --- Setup Methods ---
 
 func (s *ConfigSuite) SetupTest() {
-	s.config = NewConfigImpl()
+	s.config = New()
 }
 
 // --- Test Methods for ConfigSuite ---
@@ -252,9 +245,9 @@ func (s *ConfigSuite) TestBool() {
 	})
 }
 
-// --- Test Methods for LoadEnvironmentSuite ---
+// --- Test Methods for LoadSuite ---
 
-func (s *LoadEnvironmentSuite) setEnvVar(key string, value string) {
+func (s *LoadSuite) setEnvVar(key string, value string) {
 	err := os.Setenv(key, value)
 	s.Require().NoError(err)
 	s.T().Cleanup(func() {
@@ -262,7 +255,7 @@ func (s *LoadEnvironmentSuite) setEnvVar(key string, value string) {
 	})
 }
 
-func (s *LoadEnvironmentSuite) unsetEnvVar(key string) {
+func (s *LoadSuite) unsetEnvVar(key string) {
 	err := os.Unsetenv(key)
 	// Allow unset to fail if var doesn't exist, as that's fine for test setup.
 	if err != nil && !errors.Is(err, os.ErrNotExist) && !strings.Contains(err.Error(), "unsetenv: EINVAL: Invalid argument") { // macOS specific error for empty key
@@ -270,31 +263,31 @@ func (s *LoadEnvironmentSuite) unsetEnvVar(key string) {
 	}
 }
 
-func (s *LoadEnvironmentSuite) TestLoadString() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadString() {
+	cfg := New()
 	key := Variable[string]("ENV_STR")
 	fallback := "fb_str"
 	envVal := "env_str_val"
 
 	s.Run("EnvVarSet", func() {
 		s.setEnvVar(string(key), envVal)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envVal, cfg.String(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))                     // Ensure it's unset for this specific sub-test
-		LoadEnvironment(cfg, key, fallback)            // Use fresh config or reset
+		Load(cfg, key, fallback)                       // Use fresh config or reset
 		assert.Equal(s.T(), fallback, cfg.String(key)) // This line would fail if cfg is not reset or key re-added
 
 		// Corrected approach for EnvVarNotSet
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.String(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadInt() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadInt() {
+	cfg := New()
 	key := Variable[int]("ENV_INT")
 	fallback := 100
 	envValStr := "200"
@@ -302,25 +295,25 @@ func (s *LoadEnvironmentSuite) TestLoadInt() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValInt, cfg.Int(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-an-int")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadInt8() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadInt8() {
+	cfg := New()
 	key := Variable[int8]("ENV_INT8")
 	fallback := int8(10)
 	envValStr := "20"
@@ -328,31 +321,31 @@ func (s *LoadEnvironmentSuite) TestLoadInt8() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValInt8, cfg.Int8(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int8(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-an-int8")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int8(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "129") // Out of bounds for int8
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int8(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadInt16() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadInt16() {
+	cfg := New()
 	key := Variable[int16]("ENV_INT16")
 	fallback := int16(1000)
 	envValStr := "2000"
@@ -360,31 +353,31 @@ func (s *LoadEnvironmentSuite) TestLoadInt16() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValInt16, cfg.Int16(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int16(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-an-int16")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int16(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "32768") // Out of bounds for int16
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int16(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadInt32() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadInt32() {
+	cfg := New()
 	key := Variable[int32]("ENV_INT32")
 	fallback := int32(100000)
 	envValStr := "200000"
@@ -392,31 +385,31 @@ func (s *LoadEnvironmentSuite) TestLoadInt32() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValInt32, cfg.Int32(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int32(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-an-int32")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int32(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "2147483648") // Out of bounds for int32
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int32(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadInt64() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadInt64() {
+	cfg := New()
 	key := Variable[int64]("ENV_INT64")
 	fallback := int64(1000000000)
 	envValStr := "2000000000"
@@ -424,31 +417,31 @@ func (s *LoadEnvironmentSuite) TestLoadInt64() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValInt64, cfg.Int64(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int64(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-an-int64")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int64(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "9223372036854775808") // Out of bounds for int64
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Int64(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadUint() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadUint() {
+	cfg := New()
 	key := Variable[uint]("ENV_UINT")
 	fallback := uint(100)
 	envValStr := "200"
@@ -456,31 +449,31 @@ func (s *LoadEnvironmentSuite) TestLoadUint() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValUint, cfg.Uint(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-uint")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint(key))
 	})
 	s.Run("EnvVarSetNegative", func() {
 		s.setEnvVar(string(key), "-1") // Negative, invalid for uint
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadUint8() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadUint8() {
+	cfg := New()
 	key := Variable[uint8]("ENV_UINT8")
 	fallback := uint8(10)
 	envValStr := "20"
@@ -488,31 +481,31 @@ func (s *LoadEnvironmentSuite) TestLoadUint8() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValUint8, cfg.Uint8(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint8(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-uint8")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint8(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "256") // Out of bounds for uint8
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint8(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadUint16() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadUint16() {
+	cfg := New()
 	key := Variable[uint16]("ENV_UINT16")
 	fallback := uint16(1000)
 	envValStr := "2000"
@@ -520,31 +513,31 @@ func (s *LoadEnvironmentSuite) TestLoadUint16() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValUint16, cfg.Uint16(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint16(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-uint16")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint16(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "65536") // Out of bounds for uint16
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint16(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadUint32() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadUint32() {
+	cfg := New()
 	key := Variable[uint32]("ENV_UINT32")
 	fallback := uint32(100000)
 	envValStr := "200000"
@@ -552,31 +545,31 @@ func (s *LoadEnvironmentSuite) TestLoadUint32() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValUint32, cfg.Uint32(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint32(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-uint32")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint32(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "4294967296") // Out of bounds for uint32
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint32(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadUint64() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadUint64() {
+	cfg := New()
 	key := Variable[uint64]("ENV_UINT64")
 	fallback := uint64(1000000000)
 	envValStr := "2000000000"
@@ -584,31 +577,31 @@ func (s *LoadEnvironmentSuite) TestLoadUint64() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValUint64, cfg.Uint64(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint64(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-uint64")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint64(key))
 	})
 	s.Run("EnvVarSetOutOfBounds", func() {
 		s.setEnvVar(string(key), "18446744073709551616") // Out of bounds for uint64
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uint64(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadUintptr() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadUintptr() {
+	cfg := New()
 	key := Variable[uintptr]("ENV_UINTPTR")
 	fallback := uintptr(0x1000)
 	envValStr := "0x2000" // Using hex for variety
@@ -622,25 +615,25 @@ func (s *LoadEnvironmentSuite) TestLoadUintptr() {
 		// Or adjust the helper stub to handle "0x"
 		decimalEnvValStr := strconv.FormatUint(uint64(envValUintptr), 10)
 		s.setEnvVar(string(key), decimalEnvValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envValUintptr, cfg.Uintptr(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uintptr(key))
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-uintptr")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Uintptr(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadFloat32() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadFloat32() {
+	cfg := New()
 	key := Variable[float32]("ENV_FLOAT32")
 	fallback := float32(1.23)
 	envValStr := "4.56"
@@ -648,25 +641,25 @@ func (s *LoadEnvironmentSuite) TestLoadFloat32() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.InDelta(s.T(), envValFloat32, cfg.Float32(key), 0.0001)
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.InDelta(s.T(), fallback, freshCfg.Float32(key), 0.0001)
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-float")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.InDelta(s.T(), fallback, freshCfg.Float32(key), 0.0001)
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadFloat64() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadFloat64() {
+	cfg := New()
 	key := Variable[float64]("ENV_FLOAT64")
 	fallback := float64(1.23456)
 	envValStr := "7.89012"
@@ -674,24 +667,24 @@ func (s *LoadEnvironmentSuite) TestLoadFloat64() {
 
 	s.Run("EnvVarSetValid", func() {
 		s.setEnvVar(string(key), envValStr)
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.InDelta(s.T(), envValFloat64, cfg.Float64(key), 0.0000001)
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.InDelta(s.T(), fallback, freshCfg.Float64(key), 0.0000001)
 	})
 	s.Run("EnvVarSetInvalid", func() {
 		s.setEnvVar(string(key), "not-a-float64")
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.InDelta(s.T(), fallback, freshCfg.Float64(key), 0.0000001)
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadBool() {
+func (s *LoadSuite) TestLoadBool() {
 	key := Variable[bool]("ENV_BOOL")
 
 	testCases := []struct {
@@ -714,39 +707,39 @@ func (s *LoadEnvironmentSuite) TestLoadBool() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			currentCfg := NewConfigImpl()
+			currentCfg := New()
 			if tc.envValue != nil {
 				s.setEnvVar(string(key), *tc.envValue)
 			} else {
 				s.unsetEnvVar(string(key))
 			}
-			LoadEnvironment(currentCfg, key, tc.fallback)
+			Load(currentCfg, key, tc.fallback)
 			assert.Equal(s.T(), tc.expectedReg, currentCfg.Bool(key), "Mismatch in registered bool value")
 		})
 	}
 }
 
-func (s *LoadEnvironmentSuite) TestLoadBytes() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadBytes() {
+	cfg := New()
 	key := Variable[[]byte]("ENV_BYTES")
 	fallback := []byte("fb_bytes")
 	envVal := []byte("env_bytes_val")
 
 	s.Run("EnvVarSet", func() {
 		s.setEnvVar(string(key), string(envVal))
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envVal, cfg.Bytes(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Bytes(key))
 	})
 }
 
-func (s *LoadEnvironmentSuite) TestLoadRunes() {
-	cfg := NewConfigImpl()
+func (s *LoadSuite) TestLoadRunes() {
+	cfg := New()
 	key := Variable[[]rune]("ENV_RUNES")
 	fallback := []rune("fb_runes")
 	envValStr := "env_runes_😊"
@@ -754,14 +747,77 @@ func (s *LoadEnvironmentSuite) TestLoadRunes() {
 
 	s.Run("EnvVarSet", func() {
 		s.setEnvVar(string(key), string(envValStr)) // Store string in env
-		LoadEnvironment(cfg, key, fallback)
+		Load(cfg, key, fallback)
 		assert.Equal(s.T(), envVal, cfg.Runes(key))
 	})
 	s.Run("EnvVarNotSet", func() {
 		s.unsetEnvVar(string(key))
-		freshCfg := NewConfigImpl()
-		LoadEnvironment(freshCfg, key, fallback)
+		freshCfg := New()
+		Load(freshCfg, key, fallback)
 		assert.Equal(s.T(), fallback, freshCfg.Runes(key))
+	})
+}
+
+// --- Test Methods for ExistsSuite ---
+
+func (s *ExistsSuite) TestExists() {
+	cfg := New()
+
+	strKey1 := Variable[string]("STR_KEY_1")
+	strKey2Missing := Variable[string]("STR_KEY_2_MISSING")
+	intKey1 := Variable[int]("INT_KEY_1")
+	floatKeyMissing := Variable[float32]("FLOAT_KEY_MISSING")
+
+	Write(cfg, map[Variable[string]]string{strKey1: "val1"})
+	Write(cfg, map[Variable[int]]int{intKey1: 100})
+
+	s.Run("AllCheckedKeysExist", func() {
+		err := cfg.Exists(strKey1, intKey1)
+		assert.NoError(s.T(), err)
+	})
+
+	s.Run("SomeKeysMissing", func() {
+		err := cfg.Exists(strKey1, strKey2Missing, intKey1, floatKeyMissing)
+		s.Require().Error(err)
+
+		var missingErr MissingVariableError
+		s.Require().True(errors.As(err, &missingErr), "Error should be of type MissingVariableError")
+
+		s.Require().ErrorIs(err, ErrMissingVariable, "Error should unwrap to ErrMissingVariable")
+
+		assert.ElementsMatch(s.T(), []string{string(strKey2Missing), string(floatKeyMissing)}, missingErr.Keys)
+		assert.Contains(s.T(), err.Error(), "missing configuration variables:")
+		assert.Contains(s.T(), err.Error(), string(strKey2Missing))
+		assert.Contains(s.T(), err.Error(), string(floatKeyMissing))
+	})
+
+	s.Run("AllCheckedKeysMissing", func() {
+		missingStr := Variable[string]("COMPLETELY_MISSING_S")
+		missingInt := Variable[int]("COMPLETELY_MISSING_I")
+		err := cfg.Exists(missingStr, missingInt)
+		s.Require().Error(err)
+		var missingErr MissingVariableError
+		s.Require().True(errors.As(err, &missingErr))
+		assert.ElementsMatch(s.T(), []string{string(missingStr), string(missingInt)}, missingErr.Keys)
+		s.Require().ErrorIs(err, ErrMissingVariable)
+	})
+
+	s.Run("NoKeysToCheck", func() {
+		err := cfg.Exists()
+		assert.NoError(s.T(), err)
+	})
+
+	s.Run("ErrorTypeAndUnwrap", func() {
+		err := cfg.Exists(Variable[string]("ANY_MISSING_KEY"))
+		s.Require().Error(err)
+
+		_, ok := err.(MissingVariableError)
+		assert.True(s.T(), ok, "Error should be MissingVariableError type")
+
+		assert.ErrorIs(s.T(), err, ErrMissingVariable, "Error should unwrap to ErrMissingVariable via errors.Is")
+
+		unwrappedErr := errors.Unwrap(err)
+		assert.Equal(s.T(), ErrMissingVariable, unwrappedErr, "Unwrapped error should be exactly ErrMissingVariable")
 	})
 }
 
@@ -782,400 +838,6 @@ func (s *FormatKeysSuite) TestFormatKeys() {
 			assert.Equal(s.T(), tc.expected, formatKeys(tc.keys))
 		})
 	}
-}
-
-// --- Test Methods for CheckKeySuite ---
-func (s *CheckKeySuite) TestCheckKey() {
-	cfg := NewConfigImpl()
-
-	strKey := Variable[string]("MY_STRING")
-	intKey := Variable[int]("MY_INT")
-	boolKey := Variable[bool]("MY_BOOL")
-	float32Key := Variable[float32]("MY_FLOAT32")
-
-	missingStrKey := Variable[string]("MISSING_STRING")
-	missingIntKey := Variable[int]("MISSING_INT")
-	uintptrKey := Variable[uintptr]("MY_UINTPTR_UNINIT_MAP_SCENARIO")
-
-	cfg.regString[strKey] = "value"
-	cfg.regInt[intKey] = 123
-	cfg.regBool[boolKey] = true
-	cfg.regFloat32[float32Key] = 3.14
-
-	s.Run("ExistingKeys", func() {
-		name, exists := cfg.checkKey(strKey)
-		assert.True(s.T(), exists)
-		assert.Equal(s.T(), string(strKey), name)
-
-		name, exists = cfg.checkKey(intKey)
-		assert.True(s.T(), exists)
-		assert.Equal(s.T(), string(intKey), name)
-
-		name, exists = cfg.checkKey(boolKey)
-		assert.True(s.T(), exists)
-		assert.Equal(s.T(), string(boolKey), name)
-
-		name, exists = cfg.checkKey(float32Key)
-		assert.True(s.T(), exists)
-		assert.Equal(s.T(), string(float32Key), name)
-	})
-
-	s.Run("MissingKeys", func() {
-		name, exists := cfg.checkKey(missingStrKey)
-		assert.False(s.T(), exists)
-		assert.Equal(s.T(), string(missingStrKey), name)
-
-		name, exists = cfg.checkKey(missingIntKey)
-		assert.False(s.T(), exists)
-		assert.Equal(s.T(), string(missingIntKey), name)
-
-		name, exists = cfg.checkKey(uintptrKey)
-		assert.False(s.T(), exists)
-		assert.Equal(s.T(), string(uintptrKey), name)
-	})
-
-	s.Run("DifferentKeyTypeSameName", func() {
-		diffTypeSameNameKey := Variable[string]("MY_INT")
-		name, exists := cfg.checkKey(diffTypeSameNameKey)
-		assert.False(s.T(), exists)
-		assert.Equal(s.T(), string(diffTypeSameNameKey), name)
-
-		diffTypeSameNameKey2 := Variable[int]("MY_STRING")
-		name, exists = cfg.checkKey(diffTypeSameNameKey2)
-		assert.False(s.T(), exists)
-		assert.Equal(s.T(), string(diffTypeSameNameKey2), name)
-	})
-}
-
-// --- Test Methods for ConfigurationKeysRegisteredSuite ---
-
-func (s *ConfigurationKeysRegisteredSuite) TestConfigurationKeysRegistered() {
-	cfg := NewConfigImpl()
-
-	strKey1 := Variable[string]("STR_KEY_1")
-	strKey2Missing := Variable[string]("STR_KEY_2_MISSING")
-	intKey1 := Variable[int]("INT_KEY_1")
-	floatKeyMissing := Variable[float32]("FLOAT_KEY_MISSING")
-
-	cfg.regString[strKey1] = "val1"
-	cfg.regInt[intKey1] = 100
-
-	s.Run("AllCheckedKeysExist", func() {
-		err := cfg.ConfigurationKeysRegistered(strKey1, intKey1)
-		assert.NoError(s.T(), err)
-	})
-
-	s.Run("SomeKeysMissing", func() {
-		err := cfg.ConfigurationKeysRegistered(strKey1, strKey2Missing, intKey1, floatKeyMissing)
-		s.Require().Error(err)
-
-		var missingErr missingVariableError
-		s.Require().True(errors.As(err, &missingErr), "Error should be of type missingVariableError")
-
-		s.Require().ErrorIs(err, ErrMissingVariable, "Error should unwrap to ErrMissingVariable")
-
-		assert.ElementsMatch(s.T(), []string{string(strKey2Missing), string(floatKeyMissing)}, missingErr.Keys)
-		assert.Contains(s.T(), err.Error(), "missing configuration variables:")
-		assert.Contains(s.T(), err.Error(), string(strKey2Missing))
-		assert.Contains(s.T(), err.Error(), string(floatKeyMissing))
-	})
-
-	s.Run("AllCheckedKeysMissing", func() {
-		missingStr := Variable[string]("COMPLETELY_MISSING_S")
-		missingInt := Variable[int]("COMPLETELY_MISSING_I")
-		err := cfg.ConfigurationKeysRegistered(missingStr, missingInt)
-		s.Require().Error(err)
-		var missingErr missingVariableError
-		s.Require().True(errors.As(err, &missingErr))
-		assert.ElementsMatch(s.T(), []string{string(missingStr), string(missingInt)}, missingErr.Keys)
-		s.Require().ErrorIs(err, ErrMissingVariable)
-	})
-
-	s.Run("NoKeysToCheck", func() {
-		err := cfg.ConfigurationKeysRegistered()
-		assert.NoError(s.T(), err)
-	})
-
-	s.Run("ErrorTypeAndUnwrap", func() {
-		err := cfg.ConfigurationKeysRegistered(Variable[string]("ANY_MISSING_KEY"))
-		s.Require().Error(err)
-
-		_, ok := err.(missingVariableError)
-		assert.True(s.T(), ok, "Error should be missingVariableError type")
-
-		assert.ErrorIs(s.T(), err, ErrMissingVariable, "Error should unwrap to ErrMissingVariable via errors.Is")
-
-		unwrappedErr := errors.Unwrap(err)
-		assert.Equal(s.T(), ErrMissingVariable, unwrappedErr, "Unwrapped error should be exactly ErrMissingVariable")
-	})
-}
-
-// --- Main Test Runner ---
-
-func TestConfiguraSuite(t *testing.T) {
-	suite.Run(t, new(ConfigSuite))
-	suite.Run(t, new(LoadEnvironmentSuite))
-	suite.Run(t, new(FormatKeysSuite))
-	suite.Run(t, new(CheckKeySuite))
-	suite.Run(t, new(ConfigurationKeysRegisteredSuite))
-	suite.Run(t, new(FallbackSuite))
-	suite.Run(t, new(MergeSuite))
-}
-
-// TestMergeEmpty tests merging an empty list of configs.
-func (s *MergeSuite) TestMergeEmpty() {
-	mergedCfg := Merge()
-	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
-
-	cfgImpl, ok := mergedCfg.(*ConfigImpl)
-	s.Require().True(ok, "Merged config should be of type *ConfigImpl")
-
-	s.Empty(cfgImpl.regString, "RegString should be empty")
-	s.Empty(cfgImpl.regInt, "RegInt should be empty")
-	s.Empty(cfgImpl.regInt8, "RegInt8 should be empty")
-	s.Empty(cfgImpl.regInt16, "RegInt16 should be empty")
-	s.Empty(cfgImpl.regInt32, "RegInt32 should be empty")
-	s.Empty(cfgImpl.regInt64, "RegInt64 should be empty")
-	s.Empty(cfgImpl.regUint, "RegUint should be empty")
-	s.Empty(cfgImpl.regUint8, "RegUint8 should be empty")
-	s.Empty(cfgImpl.regUint16, "RegUint16 should be empty")
-	s.Empty(cfgImpl.regUint32, "RegUint32 should be empty")
-	s.Empty(cfgImpl.regUint64, "RegUint64 should be empty")
-	s.Empty(cfgImpl.regUintptr, "RegUintptr should be empty")
-	s.Empty(cfgImpl.regBytes, "RegBytes should be empty")
-	s.Empty(cfgImpl.regRunes, "RegRunes should be empty")
-	s.Empty(cfgImpl.regFloat32, "RegFloat32 should be empty")
-	s.Empty(cfgImpl.regFloat64, "RegFloat64 should be empty")
-	s.Empty(cfgImpl.regBool, "RegBool should be empty")
-}
-
-// TestMergeSingle tests merging a single configuration.
-func (s *MergeSuite) TestMergeSingle() {
-	cfg1 := NewConfigImpl()
-	keyStr := Variable[string]("TEST_STR")
-	LoadEnvironment(cfg1, keyStr, "value1")
-
-	keyInt := Variable[int]("TEST_INT")
-	LoadEnvironment(cfg1, keyInt, 123)
-
-	mergedCfg := Merge(cfg1)
-	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
-
-	s.Equal("value1", mergedCfg.String(keyStr))
-	s.Equal(123, mergedCfg.Int(keyInt))
-
-	// Ensure it has copied values correctly
-	cfgImpl, ok := mergedCfg.(*ConfigImpl)
-	s.Require().True(ok, "Merged config should be of type *ConfigImpl")
-	s.Equal("value1", cfgImpl.regString[keyStr])
-	s.Equal(123, cfgImpl.regInt[keyInt])
-	s.Len(cfgImpl.regString, 1)
-	s.Len(cfgImpl.regInt, 1)
-}
-
-// TestMergeTwoDistinct tests merging two configurations with distinct keys.
-func (s *MergeSuite) TestMergeTwoDistinct() {
-	cfg1 := NewConfigImpl()
-	keyStr1 := Variable[string]("STR_KEY_1")
-	LoadEnvironment(cfg1, keyStr1, "value1")
-
-	cfg2 := NewConfigImpl()
-	keyInt1 := Variable[int]("INT_KEY_1")
-	LoadEnvironment(cfg2, keyInt1, 100)
-
-	mergedCfg := Merge(cfg1, cfg2)
-	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
-
-	s.Equal("value1", mergedCfg.String(keyStr1))
-	s.Equal(100, mergedCfg.Int(keyInt1))
-
-	cfgImpl, ok := mergedCfg.(*ConfigImpl)
-	s.Require().True(ok, "Merged config should be of type *ConfigImpl")
-	s.Len(cfgImpl.regString, 1, "RegString should have 1 entry")
-	s.Equal("value1", cfgImpl.regString[keyStr1])
-	s.Len(cfgImpl.regInt, 1, "RegInt should have 1 entry")
-	s.Equal(100, cfgImpl.regInt[keyInt1])
-}
-
-// TestMergeTwoOverride tests merging two configurations where the second overrides the first.
-func (s *MergeSuite) TestMergeTwoOverride() {
-	cfg1 := NewConfigImpl()
-	keyStr := Variable[string]("OVERRIDE_STR")
-	LoadEnvironment(cfg1, keyStr, "original_value")
-	keyInt := Variable[int]("SHARED_INT")
-	LoadEnvironment(cfg1, keyInt, 111) // This key is only in cfg1
-
-	cfg2 := NewConfigImpl()
-	LoadEnvironment(cfg2, keyStr, "overridden_value") // Override
-	keyBool := Variable[bool]("NEW_BOOL")
-	LoadEnvironment(cfg2, keyBool, true) // This key is only in cfg2
-
-	mergedCfg := Merge(cfg1, cfg2)
-	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
-
-	s.Equal("overridden_value", mergedCfg.String(keyStr)) // Overridden
-	s.Equal(111, mergedCfg.Int(keyInt))                   // From cfg1
-	s.True(mergedCfg.Bool(keyBool))                       // From cfg2
-
-	cfgImpl, ok := mergedCfg.(*ConfigImpl)
-	s.Require().True(ok, "Merged config should be of type *ConfigImpl")
-	s.Len(cfgImpl.regString, 1)
-	s.Equal("overridden_value", cfgImpl.regString[keyStr])
-	s.Len(cfgImpl.regInt, 1)
-	s.Equal(111, cfgImpl.regInt[keyInt])
-	s.Len(cfgImpl.regBool, 1)
-	s.True(cfgImpl.regBool[keyBool])
-}
-
-// TestMergeMultiple tests merging multiple (three) configurations with overrides.
-func (s *MergeSuite) TestMergeMultiple() {
-	cfg1 := NewConfigImpl()
-	keyStr1 := Variable[string]("S1")
-	LoadEnvironment(cfg1, keyStr1, "val_s1_cfg1") // In cfg1
-	keyShared := Variable[string]("SHARED_KEY")
-	LoadEnvironment(cfg1, keyShared, "shared_cfg1") // In cfg1, overridden by cfg2, then by cfg3
-
-	cfg2 := NewConfigImpl()
-	keyInt1 := Variable[int]("I1")
-	LoadEnvironment(cfg2, keyInt1, 222)             // In cfg2
-	LoadEnvironment(cfg2, keyShared, "shared_cfg2") // Override from cfg1
-
-	cfg3 := NewConfigImpl()
-	keyBool1 := Variable[bool]("B1")
-	LoadEnvironment(cfg3, keyBool1, true)           // In cfg3
-	LoadEnvironment(cfg3, keyShared, "shared_cfg3") // Override from cfg2
-
-	mergedCfg := Merge(cfg1, cfg2, cfg3)
-	s.Require().NotNil(mergedCfg)
-
-	s.Equal("val_s1_cfg1", mergedCfg.String(keyStr1))
-	s.Equal("shared_cfg3", mergedCfg.String(keyShared)) // Final override from cfg3
-	s.Equal(222, mergedCfg.Int(keyInt1))
-	s.True(mergedCfg.Bool(keyBool1))
-
-	cfgImpl, ok := mergedCfg.(*ConfigImpl)
-	s.Require().True(ok)
-	s.Len(cfgImpl.regString, 2) // S1, SHARED_KEY
-	s.Len(cfgImpl.regInt, 1)    // I1
-	s.Len(cfgImpl.regBool, 1)   // B1
-}
-
-// TestMergeAllTypes ensures all supported types are merged correctly.
-func (s *MergeSuite) TestMergeAllTypes() {
-	cfg1 := NewConfigImpl()
-	cfg2 := NewConfigImpl()
-
-	// Define keys and values
-	kStr := Variable[string]("TYPE_STR")
-	vStr1, vStr2 := "string_val1", "string_val2"
-	kInt := Variable[int]("TYPE_INT")
-	vInt1, vInt2 := 10, 20
-	kInt8 := Variable[int8]("TYPE_INT8")
-	vInt8_1, vInt8_2 := int8(1), int8(2)
-	kInt16 := Variable[int16]("TYPE_INT16")
-	vInt16_1, vInt16_2 := int16(100), int16(200)
-	kInt32 := Variable[int32]("TYPE_INT32")
-	vInt32_1, vInt32_2 := int32(1000), int32(2000)
-	kInt64 := Variable[int64]("TYPE_INT64")
-	vInt64_1, vInt64_2 := int64(10000), int64(20000)
-	kUint := Variable[uint]("TYPE_UINT")
-	vUint1 := uint(1)
-	kUint8 := Variable[uint8]("TYPE_UINT8")
-	vUint8_1 := uint8(10)
-	kUint16 := Variable[uint16]("TYPE_UINT16")
-	vUint16_1 := uint16(100)
-	kUint32 := Variable[uint32]("TYPE_UINT32")
-	vUint32_1 := uint32(1000)
-	kUint64 := Variable[uint64]("TYPE_UINT64")
-	vUint64_1 := uint64(10000)
-	kUintptr := Variable[uintptr]("TYPE_UINTPTR")
-	vUintptr1 := uintptr(0x1)
-	kBytes := Variable[[]byte]("TYPE_BYTES")
-	vBytes2 := []byte("bytes2")
-	kRunes := Variable[[]rune]("TYPE_RUNES")
-	vRunes2 := []rune("runes2")
-	kFloat32 := Variable[float32]("TYPE_FLOAT32")
-	vFloat32_2 := float32(2.5)
-	kFloat64 := Variable[float64]("TYPE_FLOAT64")
-	vFloat64_2 := 20.5
-	kBool := Variable[bool]("TYPE_BOOL")
-	vBool1, vBool2 := false, true // Bool1 is in cfg1, Bool2 will override
-
-	// Load into cfg1 (these will be overridden or kept if not in cfg2)
-	LoadEnvironment(cfg1, kStr, vStr1)
-	LoadEnvironment(cfg1, kInt, vInt1)
-	LoadEnvironment(cfg1, kInt8, vInt8_1)
-	LoadEnvironment(cfg1, kInt16, vInt16_1)
-	LoadEnvironment(cfg1, kInt32, vInt32_1)
-	LoadEnvironment(cfg1, kInt64, vInt64_1)
-	// Uint types only in cfg1
-	LoadEnvironment(cfg1, kUint, vUint1)
-	LoadEnvironment(cfg1, kUint8, vUint8_1)
-	LoadEnvironment(cfg1, kUint16, vUint16_1)
-	LoadEnvironment(cfg1, kUint32, vUint32_1)
-	LoadEnvironment(cfg1, kUint64, vUint64_1)
-	LoadEnvironment(cfg1, kUintptr, vUintptr1)
-	LoadEnvironment(cfg1, kBool, vBool1) // Will be overridden
-
-	// Load into cfg2 (these will override cfg1 or be new)
-	LoadEnvironment(cfg2, kStr, vStr2)      // Override
-	LoadEnvironment(cfg2, kInt, vInt2)      // Override
-	LoadEnvironment(cfg2, kInt8, vInt8_2)   // Override
-	LoadEnvironment(cfg2, kInt16, vInt16_2) // Override
-	LoadEnvironment(cfg2, kInt32, vInt32_2) // Override
-	LoadEnvironment(cfg2, kInt64, vInt64_2) // Override
-	// Slice and float types only in cfg2
-	LoadEnvironment(cfg2, kBytes, vBytes2)
-	LoadEnvironment(cfg2, kRunes, vRunes2)
-	LoadEnvironment(cfg2, kFloat32, vFloat32_2)
-	LoadEnvironment(cfg2, kFloat64, vFloat64_2)
-	LoadEnvironment(cfg2, kBool, vBool2) // Override
-
-	mergedCfg := Merge(cfg1, cfg2)
-	s.Require().NotNil(mergedCfg)
-
-	// Assertions for overridden values (from cfg2)
-	s.Equal(vStr2, mergedCfg.String(kStr))
-	s.Equal(vInt2, mergedCfg.Int(kInt))
-	s.Equal(vInt8_2, mergedCfg.Int8(kInt8))
-	s.Equal(vInt16_2, mergedCfg.Int16(kInt16))
-	s.Equal(vInt32_2, mergedCfg.Int32(kInt32))
-	s.Equal(vInt64_2, mergedCfg.Int64(kInt64))
-	s.Equal(vBool2, mergedCfg.Bool(kBool))
-
-	// Assertions for values only in cfg1
-	s.Equal(vUint1, mergedCfg.Uint(kUint))
-	s.Equal(vUint8_1, mergedCfg.Uint8(kUint8))
-	s.Equal(vUint16_1, mergedCfg.Uint16(kUint16))
-	s.Equal(vUint32_1, mergedCfg.Uint32(kUint32))
-	s.Equal(vUint64_1, mergedCfg.Uint64(kUint64))
-	s.Equal(vUintptr1, mergedCfg.Uintptr(kUintptr))
-
-	// Assertions for values only in cfg2
-	s.Equal(vBytes2, mergedCfg.Bytes(kBytes))
-	s.Equal(vRunes2, mergedCfg.Runes(kRunes))
-	s.Equal(vFloat32_2, mergedCfg.Float32(kFloat32))
-	s.Equal(vFloat64_2, mergedCfg.Float64(kFloat64))
-
-	cfgImpl, ok := mergedCfg.(*ConfigImpl)
-	s.Require().True(ok)
-	s.Len(cfgImpl.regString, 1)
-	s.Len(cfgImpl.regInt, 1)
-	s.Len(cfgImpl.regInt8, 1)
-	s.Len(cfgImpl.regInt16, 1)
-	s.Len(cfgImpl.regInt32, 1)
-	s.Len(cfgImpl.regInt64, 1)
-	s.Len(cfgImpl.regUint, 1)
-	s.Len(cfgImpl.regUint8, 1)
-	s.Len(cfgImpl.regUint16, 1)
-	s.Len(cfgImpl.regUint32, 1)
-	s.Len(cfgImpl.regUint64, 1)
-	s.Len(cfgImpl.regUintptr, 1)
-	s.Len(cfgImpl.regBytes, 1)
-	s.Len(cfgImpl.regRunes, 1)
-	s.Len(cfgImpl.regFloat32, 1)
-	s.Len(cfgImpl.regFloat64, 1)
-	s.Len(cfgImpl.regBool, 1)
 }
 
 func (s *FallbackSuite) TestFallbackString() {
@@ -1269,4 +931,332 @@ func (s *FallbackSuite) TestFallbackBool() {
 			s.Equal(tc.expected, result)
 		})
 	}
+}
+
+// --- Test Methods for MergeSuite ---
+
+func (s *MergeSuite) TestMergeEmpty() {
+	mergedCfg := Merge()
+	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
+
+	cfgImpl, ok := mergedCfg.(*config)
+	s.Require().True(ok, "Merged config should be of type *config")
+
+	s.Empty(cfgImpl.regString, "RegString should be empty")
+	s.Empty(cfgImpl.regInt, "RegInt should be empty")
+	s.Empty(cfgImpl.regInt8, "RegInt8 should be empty")
+	s.Empty(cfgImpl.regInt16, "RegInt16 should be empty")
+	s.Empty(cfgImpl.regInt32, "RegInt32 should be empty")
+	s.Empty(cfgImpl.regInt64, "RegInt64 should be empty")
+	s.Empty(cfgImpl.regUint, "RegUint should be empty")
+	s.Empty(cfgImpl.regUint8, "RegUint8 should be empty")
+	s.Empty(cfgImpl.regUint16, "RegUint16 should be empty")
+	s.Empty(cfgImpl.regUint32, "RegUint32 should be empty")
+	s.Empty(cfgImpl.regUint64, "RegUint64 should be empty")
+	s.Empty(cfgImpl.regUintptr, "RegUintptr should be empty")
+	s.Empty(cfgImpl.regBytes, "RegBytes should be empty")
+	s.Empty(cfgImpl.regRunes, "RegRunes should be empty")
+	s.Empty(cfgImpl.regFloat32, "RegFloat32 should be empty")
+	s.Empty(cfgImpl.regFloat64, "RegFloat64 should be empty")
+	s.Empty(cfgImpl.regBool, "RegBool should be empty")
+}
+
+func (s *MergeSuite) TestMergeSingle() {
+	cfg1 := New()
+	keyStr := Variable[string]("TEST_STR")
+	Load(cfg1, keyStr, "value1")
+
+	keyInt := Variable[int]("TEST_INT")
+	Load(cfg1, keyInt, 123)
+
+	mergedCfg := Merge(cfg1)
+	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
+
+	s.Equal("value1", mergedCfg.String(keyStr))
+	s.Equal(123, mergedCfg.Int(keyInt))
+
+	// Ensure it has copied values correctly
+	cfgImpl, ok := mergedCfg.(*config)
+	s.Require().True(ok, "Merged config should be of type *config")
+	s.Equal("value1", cfgImpl.regString[keyStr])
+	s.Equal(123, cfgImpl.regInt[keyInt])
+	s.Len(cfgImpl.regString, 1)
+	s.Len(cfgImpl.regInt, 1)
+}
+
+func (s *MergeSuite) TestMergeTwoDistinct() {
+	cfg1 := New()
+	keyStr1 := Variable[string]("STR_KEY_1")
+	Load(cfg1, keyStr1, "value1")
+
+	cfg2 := New()
+	keyInt1 := Variable[int]("INT_KEY_1")
+	Load(cfg2, keyInt1, 100)
+
+	mergedCfg := Merge(cfg1, cfg2)
+	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
+
+	s.Equal("value1", mergedCfg.String(keyStr1))
+	s.Equal(100, mergedCfg.Int(keyInt1))
+
+	cfgImpl, ok := mergedCfg.(*config)
+	s.Require().True(ok, "Merged config should be of type *config")
+	s.Len(cfgImpl.regString, 1, "RegString should have 1 entry")
+	s.Equal("value1", cfgImpl.regString[keyStr1])
+	s.Len(cfgImpl.regInt, 1, "RegInt should have 1 entry")
+	s.Equal(100, cfgImpl.regInt[keyInt1])
+}
+
+func (s *MergeSuite) TestMergeTwoOverride() {
+	cfg1 := New()
+	keyStr := Variable[string]("OVERRIDE_STR")
+	Load(cfg1, keyStr, "original_value")
+	keyInt := Variable[int]("SHARED_INT")
+	Load(cfg1, keyInt, 111) // This key is only in cfg1
+
+	cfg2 := New()
+	Load(cfg2, keyStr, "overridden_value") // Override
+	keyBool := Variable[bool]("NEW_BOOL")
+	Load(cfg2, keyBool, true) // This key is only in cfg2
+
+	mergedCfg := Merge(cfg1, cfg2)
+	s.Require().NotNil(mergedCfg, "Merged config should not be nil")
+
+	s.Equal("overridden_value", mergedCfg.String(keyStr)) // Overridden
+	s.Equal(111, mergedCfg.Int(keyInt))                   // From cfg1
+	s.True(mergedCfg.Bool(keyBool))                       // From cfg2
+
+	cfgImpl, ok := mergedCfg.(*config)
+	s.Require().True(ok, "Merged config should be of type *config")
+	s.Len(cfgImpl.regString, 1)
+	s.Equal("overridden_value", cfgImpl.regString[keyStr])
+	s.Len(cfgImpl.regInt, 1)
+	s.Equal(111, cfgImpl.regInt[keyInt])
+	s.Len(cfgImpl.regBool, 1)
+	s.True(cfgImpl.regBool[keyBool])
+}
+
+func (s *MergeSuite) TestMergeMultiple() {
+	cfg1 := New()
+	keyStr1 := Variable[string]("S1")
+	Load(cfg1, keyStr1, "val_s1_cfg1") // In cfg1
+	keyShared := Variable[string]("SHARED_KEY")
+	Load(cfg1, keyShared, "shared_cfg1") // In cfg1, overridden by cfg2, then by cfg3
+
+	cfg2 := New()
+	keyInt1 := Variable[int]("I1")
+	Load(cfg2, keyInt1, 222)             // In cfg2
+	Load(cfg2, keyShared, "shared_cfg2") // Override from cfg1
+
+	cfg3 := New()
+	keyBool1 := Variable[bool]("B1")
+	Load(cfg3, keyBool1, true)           // In cfg3
+	Load(cfg3, keyShared, "shared_cfg3") // Override from cfg2
+
+	mergedCfg := Merge(cfg1, cfg2, cfg3)
+	s.Require().NotNil(mergedCfg)
+
+	s.Equal("val_s1_cfg1", mergedCfg.String(keyStr1))
+	s.Equal("shared_cfg3", mergedCfg.String(keyShared)) // Final override from cfg3
+	s.Equal(222, mergedCfg.Int(keyInt1))
+	s.True(mergedCfg.Bool(keyBool1))
+
+	cfgImpl, ok := mergedCfg.(*config)
+	s.Require().True(ok)
+	s.Len(cfgImpl.regString, 2) // S1, SHARED_KEY
+	s.Len(cfgImpl.regInt, 1)    // I1
+	s.Len(cfgImpl.regBool, 1)   // B1
+}
+
+func (s *MergeSuite) TestMergeAllTypes() {
+	cfg1 := New()
+	cfg2 := New()
+
+	// Define keys and values
+	kStr := Variable[string]("TYPE_STR")
+	vStr1, vStr2 := "string_val1", "string_val2"
+	kInt := Variable[int]("TYPE_INT")
+	vInt1, vInt2 := 10, 20
+	kInt8 := Variable[int8]("TYPE_INT8")
+	vInt8_1, vInt8_2 := int8(1), int8(2)
+	kInt16 := Variable[int16]("TYPE_INT16")
+	vInt16_1, vInt16_2 := int16(100), int16(200)
+	kInt32 := Variable[int32]("TYPE_INT32")
+	vInt32_1, vInt32_2 := int32(1000), int32(2000)
+	kInt64 := Variable[int64]("TYPE_INT64")
+	vInt64_1, vInt64_2 := int64(10000), int64(20000)
+	kUint := Variable[uint]("TYPE_UINT")
+	vUint1 := uint(1)
+	kUint8 := Variable[uint8]("TYPE_UINT8")
+	vUint8_1 := uint8(10)
+	kUint16 := Variable[uint16]("TYPE_UINT16")
+	vUint16_1 := uint16(100)
+	kUint32 := Variable[uint32]("TYPE_UINT32")
+	vUint32_1 := uint32(1000)
+	kUint64 := Variable[uint64]("TYPE_UINT64")
+	vUint64_1 := uint64(10000)
+	kUintptr := Variable[uintptr]("TYPE_UINTPTR")
+	vUintptr1 := uintptr(0x1)
+	kBytes := Variable[[]byte]("TYPE_BYTES")
+	vBytes2 := []byte("bytes2")
+	kRunes := Variable[[]rune]("TYPE_RUNES")
+	vRunes2 := []rune("runes2")
+	kFloat32 := Variable[float32]("TYPE_FLOAT32")
+	vFloat32_2 := float32(2.5)
+	kFloat64 := Variable[float64]("TYPE_FLOAT64")
+	vFloat64_2 := 20.5
+	kBool := Variable[bool]("TYPE_BOOL")
+	vBool1, vBool2 := false, true // Bool1 is in cfg1, Bool2 will override
+
+	// Load into cfg1 (these will be overridden or kept if not in cfg2)
+	Load(cfg1, kStr, vStr1)
+	Load(cfg1, kInt, vInt1)
+	Load(cfg1, kInt8, vInt8_1)
+	Load(cfg1, kInt16, vInt16_1)
+	Load(cfg1, kInt32, vInt32_1)
+	Load(cfg1, kInt64, vInt64_1)
+	// Uint types only in cfg1
+	Load(cfg1, kUint, vUint1)
+	Load(cfg1, kUint8, vUint8_1)
+	Load(cfg1, kUint16, vUint16_1)
+	Load(cfg1, kUint32, vUint32_1)
+	Load(cfg1, kUint64, vUint64_1)
+	Load(cfg1, kUintptr, vUintptr1)
+	Load(cfg1, kBool, vBool1) // Will be overridden
+
+	// Load into cfg2 (these will override cfg1 or be new)
+	Load(cfg2, kStr, vStr2)      // Override
+	Load(cfg2, kInt, vInt2)      // Override
+	Load(cfg2, kInt8, vInt8_2)   // Override
+	Load(cfg2, kInt16, vInt16_2) // Override
+	Load(cfg2, kInt32, vInt32_2) // Override
+	Load(cfg2, kInt64, vInt64_2) // Override
+	// Slice and float types only in cfg2
+	Load(cfg2, kBytes, vBytes2)
+	Load(cfg2, kRunes, vRunes2)
+	Load(cfg2, kFloat32, vFloat32_2)
+	Load(cfg2, kFloat64, vFloat64_2)
+	Load(cfg2, kBool, vBool2) // Override
+
+	mergedCfg := Merge(cfg1, cfg2)
+	s.Require().NotNil(mergedCfg)
+
+	// Assertions for overridden values (from cfg2)
+	s.Equal(vStr2, mergedCfg.String(kStr))
+	s.Equal(vInt2, mergedCfg.Int(kInt))
+	s.Equal(vInt8_2, mergedCfg.Int8(kInt8))
+	s.Equal(vInt16_2, mergedCfg.Int16(kInt16))
+	s.Equal(vInt32_2, mergedCfg.Int32(kInt32))
+	s.Equal(vInt64_2, mergedCfg.Int64(kInt64))
+	s.Equal(vBool2, mergedCfg.Bool(kBool))
+
+	// Assertions for values only in cfg1
+	s.Equal(vUint1, mergedCfg.Uint(kUint))
+	s.Equal(vUint8_1, mergedCfg.Uint8(kUint8))
+	s.Equal(vUint16_1, mergedCfg.Uint16(kUint16))
+	s.Equal(vUint32_1, mergedCfg.Uint32(kUint32))
+	s.Equal(vUint64_1, mergedCfg.Uint64(kUint64))
+	s.Equal(vUintptr1, mergedCfg.Uintptr(kUintptr))
+
+	// Assertions for values only in cfg2
+	s.Equal(vBytes2, mergedCfg.Bytes(kBytes))
+	s.Equal(vRunes2, mergedCfg.Runes(kRunes))
+	s.Equal(vFloat32_2, mergedCfg.Float32(kFloat32))
+	s.Equal(vFloat64_2, mergedCfg.Float64(kFloat64))
+
+	cfgImpl, ok := mergedCfg.(*config)
+	s.Require().True(ok)
+	s.Len(cfgImpl.regString, 1)
+	s.Len(cfgImpl.regInt, 1)
+	s.Len(cfgImpl.regInt8, 1)
+	s.Len(cfgImpl.regInt16, 1)
+	s.Len(cfgImpl.regInt32, 1)
+	s.Len(cfgImpl.regInt64, 1)
+	s.Len(cfgImpl.regUint, 1)
+	s.Len(cfgImpl.regUint8, 1)
+	s.Len(cfgImpl.regUint16, 1)
+	s.Len(cfgImpl.regUint32, 1)
+	s.Len(cfgImpl.regUint64, 1)
+	s.Len(cfgImpl.regUintptr, 1)
+	s.Len(cfgImpl.regBytes, 1)
+	s.Len(cfgImpl.regRunes, 1)
+	s.Len(cfgImpl.regFloat32, 1)
+	s.Len(cfgImpl.regFloat64, 1)
+	s.Len(cfgImpl.regBool, 1)
+}
+
+// --- Test Methods for CheckKeySuite ---
+
+func (s *CheckKeySuite) TestCheckKey() {
+	cfg := New()
+
+	strKey := Variable[string]("MY_STRING")
+	intKey := Variable[int]("MY_INT")
+	boolKey := Variable[bool]("MY_BOOL")
+	float32Key := Variable[float32]("MY_FLOAT32")
+
+	missingStrKey := Variable[string]("MISSING_STRING")
+	missingIntKey := Variable[int]("MISSING_INT")
+	uintptrKey := Variable[uintptr]("MY_UINTPTR_UNINIT_MAP_SCENARIO")
+
+	cfg.regString[strKey] = "value"
+	cfg.regInt[intKey] = 123
+	cfg.regBool[boolKey] = true
+	cfg.regFloat32[float32Key] = 3.14
+
+	s.Run("ExistingKeys", func() {
+		name, exists := cfg.checkKey(strKey)
+		assert.True(s.T(), exists)
+		assert.Equal(s.T(), string(strKey), name)
+
+		name, exists = cfg.checkKey(intKey)
+		assert.True(s.T(), exists)
+		assert.Equal(s.T(), string(intKey), name)
+
+		name, exists = cfg.checkKey(boolKey)
+		assert.True(s.T(), exists)
+		assert.Equal(s.T(), string(boolKey), name)
+
+		name, exists = cfg.checkKey(float32Key)
+		assert.True(s.T(), exists)
+		assert.Equal(s.T(), string(float32Key), name)
+	})
+
+	s.Run("MissingKeys", func() {
+		name, exists := cfg.checkKey(missingStrKey)
+		assert.False(s.T(), exists)
+		assert.Equal(s.T(), string(missingStrKey), name)
+
+		name, exists = cfg.checkKey(missingIntKey)
+		assert.False(s.T(), exists)
+		assert.Equal(s.T(), string(missingIntKey), name)
+
+		name, exists = cfg.checkKey(uintptrKey)
+		assert.False(s.T(), exists)
+		assert.Equal(s.T(), string(uintptrKey), name)
+	})
+
+	s.Run("DifferentKeyTypeSameName", func() {
+		diffTypeSameNameKey := Variable[string]("MY_INT")
+		name, exists := cfg.checkKey(diffTypeSameNameKey)
+		assert.False(s.T(), exists)
+		assert.Equal(s.T(), string(diffTypeSameNameKey), name)
+
+		diffTypeSameNameKey2 := Variable[int]("MY_STRING")
+		name, exists = cfg.checkKey(diffTypeSameNameKey2)
+		assert.False(s.T(), exists)
+		assert.Equal(s.T(), string(diffTypeSameNameKey2), name)
+	})
+}
+
+// --- Main Test Runner ---
+
+func TestConfiguraSuite(t *testing.T) {
+	suite.Run(t, new(ConfigSuite))
+	suite.Run(t, new(LoadSuite))
+	suite.Run(t, new(FormatKeysSuite))
+	suite.Run(t, new(CheckKeySuite))
+	suite.Run(t, new(ExistsSuite))
+	suite.Run(t, new(FallbackSuite))
+	suite.Run(t, new(MergeSuite))
 }

--- a/configura_thread_safety_test.go
+++ b/configura_thread_safety_test.go
@@ -14,7 +14,7 @@ type ThreadSafetySuite struct {
 }
 
 func (s *ThreadSafetySuite) SetupTest() {
-	s.config = NewConfigImpl()
+	s.config = New()
 }
 
 func (s *ThreadSafetySuite) runConcurrently(goroutines int, f func(i int)) {


### PR DESCRIPTION
﻿Cleaned up the public API to be more concise and user-friendly:

- Renamed `NewConfigImpl()` → `New()`
- Renamed `LoadEnvironment()` → `Load()` 
- Renamed `ConfigurationKeysRegistered()` → `Exists()`
- Made internal `ConfigImpl` type private (`config`)
- Updated all examples and documentation to reflect the new naming

The functionality remains the same, just with shorter and cleaner method names that follow Go conventions better.